### PR TITLE
chore: [oauth2client] oauth2client is a dep from google

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 venv
 .idea
-.pyc
+*.pyc

--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ Authentication against BambooHR is done via an API Access Key
 ## Installation
 1. Install the dependencies: `sudo pip install -r requirements.txt` (or create a virtualenv to do it in)
 2. Find out you BambooHR employee ID. This can be done by logging in to BambooHR and going to "My Info". Your employee ID is at the end of the URL. eg `https://yourcompany.bamboohr.com/employees/pto/?id=12345`
-3. Create a Google Application with access to your Calendar and get the secrets stored locally: TBD
-4. If possible, get an Access Key for BambooHR. This is done by logging into BambooHR, selecting your avatar/initials in the top-right and selecting **API Keys**. If this is not possible (it's not available for all users) you can still login with a username and password
-5. If you do not want to use your default calendar, find the Calendar ID for the calendar you want to use:
+3. If possible, get an Access Key for BambooHR. This is done by logging into BambooHR, selecting your avatar/initials in the top-right and selecting **API Keys**. If this is not possible (it's not available for all users) you can still login with a username and password
+4. If you do not want to use your default calendar, find the Calendar ID for the calendar you want to use:
     1. Open up Google Calendars
     2. Hit the three dots next to the calendar you want to use and select "Setting and sharing"
     3. Calendar ID is listed under the "Integrate Calendar" section, eg `1234567890abcdefghijk@group.calendar.google.com`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# bamboohr-google-calendar-sync
+# BambooHR to Google Calendar Sync tool
 Application for syncing your personal calendar between BambooHR and Google Calendars.
 BambooHR provides iCal links for your entire company and "Who's off today" calendars, but does not give you a personal calendar with your own Time Off requests out of the box. This application fills the void by populating a google calendar of your choice with your BambooHR Time Off requests
 
@@ -22,6 +22,7 @@ Once you have run through this initial configuration, your preferences will be s
 
 Example Runthrough:
 ```
+$ python bamboohr-google-calendar-sync.py
 BambooHR Company: mycompany
 Employee ID: 123456
 BambooHR Access Token (leave blank to use username/password):

--- a/config.py
+++ b/config.py
@@ -1,7 +1,6 @@
 import logging
 import os
 from ConfigParser import SafeConfigParser, NoSectionError, NoOptionError
-from getpass import getpass
 from os.path import expanduser
 
 
@@ -32,6 +31,7 @@ class Config:
             # Check all the mandatory things
             c = self.get_config()
             c[self.BAMBOO_SECTION]['company']
+            c[self.BAMBOO_SECTION]['token']
             c[self.BAMBOO_SECTION]['employee_id']
             c[self.GCAL_SECTION]['calendar_id']
         except (NoSectionError, NoOptionError, KeyError):
@@ -46,7 +46,6 @@ class Config:
         else:
             logging.debug('No token entered - using username/password')
             self.config.set(self.BAMBOO_SECTION, 'user', raw_input('BambooHR username: '))
-            self.config.set(self.BAMBOO_SECTION, 'password', getpass())
 
         calendar_id = raw_input("Google Calendar ID (use 'personal' for the your calendar): ") or 'personal'
         self.config.set(self.GCAL_SECTION, 'calendar_id',
@@ -55,7 +54,6 @@ class Config:
 
     def save_token(self, token):
         self.config.set(self.BAMBOO_SECTION, 'token', token)
-        # TODO: Clear the username/password?
         self._save()
 
     def _save(self):

--- a/google_calendar_client.py
+++ b/google_calendar_client.py
@@ -39,7 +39,7 @@ class GoogleCalendar:
         store = Storage(credential_path)
         credentials = store.get()
         if not credentials or credentials.invalid:
-            flow = client.flow_from_clientsecrets(credential_path + CLIENT_SECRET_FILE, SCOPES)
+            flow = client.flow_from_clientsecrets(CLIENT_SECRET_FILE, SCOPES)
             flow.user_agent = APPLICATION_NAME
             if flags:
                 credentials = tools.run_flow(flow, store, flags)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyBambooHR
 google-api-python-client
+oauth2client


### PR DESCRIPTION
If not added you get

```
~m/bamboohr-google-calendar-sync ◎ python bamboohr-google-calendar-sync.py
Traceback (most recent call last):
  File "bamboohr-google-calendar-sync.py", line 10, in <module>
    from google_calendar_client import GoogleCalendar
  File "/home/thorsten/src/mysterion/bamboohr-google-calendar-sync/google_calendar_client.py", line 8, in <module>
    from oauth2client import client
ImportError: No module named oauth2client
```